### PR TITLE
feat: Add credential panel with clipboard copy functionality

### DIFF
--- a/passvault_tui/style.css
+++ b/passvault_tui/style.css
@@ -89,3 +89,13 @@ Screen {
     margin-top: 1;
     height: 1;
 }
+
+#credential-modal {
+    align: center middle;
+    border: solid $primary;
+    background: $boost;
+    layer: overlay;
+    width: 50;
+    height: 11;
+    padding: 1 2;
+}


### PR DESCRIPTION
Add credential panel with key bindings for copying username and password to clipboard

- Implement CredentialPanel as focusable Vertical container
- Add key bindings: 'c' to copy username, 'p' to copy password, 'Escape' to close
- Integrate ClipboardManager for secure clipboard operations
- Add notifications for successful copy operations
- Add comprehensive logging for debugging
- Support passing credential data on panel mount